### PR TITLE
Issue 14 Display note for unsaved changes

### DIFF
--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -5,3 +5,7 @@
 .hideDiscard {
   display: none;
 }
+
+.reminder-saved-note{
+  color: red;
+}

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -11,6 +11,11 @@
             {{reminder.title}}
           {{/link-to}}
         </h3>
+        {{#if reminder.hasDirtyAttributes}}
+          <span class='reminder-saved-note'>
+            *Reminder has not been saved
+          </span>
+        {{/if}}
         <p>
           {{reminder.date}}
         </p>

--- a/tests/acceptance/reminder-form-test.js
+++ b/tests/acceptance/reminder-form-test.js
@@ -145,3 +145,30 @@ test('edit reminder discard changes', function(assert) {
     assert.equal(find('.spec-selected-notes').text().trim(), 'Really good ones', 'notes text should match original reminder');
   })
 })
+
+test('shows unsaved note in reminder when not saved', function(assert) {
+  visit('/reminders');
+
+  click('.spec-link-new-reminder');
+
+  fillIn('.spec-title-field', 'Write great tests');
+  fillIn('.spec-notes-field', 'Really good ones');
+
+  click('.spec-add-reminder')
+
+  click('.spec-reminder-title:first');
+
+  click('.spec-link-edit-reminder');
+
+  fillIn('.spec-title-field', 'Eat pizza');
+
+  andThen(function() {
+    assert.equal(find('.reminder-saved-note').length, 1, 'displays note for unsaved reminder');
+  })
+
+  click('.spec-discard-changes');
+
+  andThen(function() {
+    assert.equal(find('.reminder-saved-note').length, 0, 'does not display note');
+  })
+})


### PR DESCRIPTION
## Purpose

Feature that displays note next to reminder in reminders list that has unsaved changes.

## Approach

Added an if statement inside the reminders list to display the note if the model has dirty attributes.

### Learning

Googled dirty attributes and looked at the docs.

### Test coverage 

Tested if the note is displayed when the reminder has been edited as well as not displaying when the changes have been saved.

closes #14 